### PR TITLE
Feature: Provide Convenience Wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - main
 
-
 jobs:
     docs:
         name: Docs
@@ -25,7 +24,6 @@ jobs:
                   RUSTDOCFLAGS: -D warnings
 
     publish-dry-run:
-        if: ${{ false }}  # disable for now
         name: Publish dry run
         runs-on: ubuntu-latest
         steps:
@@ -39,4 +37,3 @@ jobs:
 
             - name: Dry run
               run: cargo publish --dry-run
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
               uses: taiki-e/install-action@cargo-llvm-cov
 
             - name: Run Unit Tests
-              run: cargo make cov
+              run: cargo make cov-ci
 
             - name: Upload coverage data to codecov
               uses: codecov/codecov-action@v3
               with:
+                  token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
                   files: lcov.info
+                  fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 *.pdb
 
 .DS_Store
+
+lcov.info

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -61,6 +61,10 @@ args = [
 command = "cargo"
 args = ["llvm-cov", "${@}"]
 
+[tasks.cov-ci]
+command = "cargo"
+args = ["llvm-cov", "--lcov", "--output-path", "lcov.info", "${@}"]
+
 [tasks.audit]
 command = "cargo"
 args = ["audit"]


### PR DESCRIPTION
Add `inject::ProvideResult<dyn Repository>` and `inject::provide(...)` to make the `Ok(Box::new(...))` less obtrusive.

```rs
#[async_trait]
impl inject::Provider<dyn Repository> for PostgresRepositoryProvider {
    async fn provide(&self, i: &inject::Inject) -> inject::ProvideResult<dyn Repository> {
        let pool = i.get::<Pool<Postgres>>()?;
        inject::provide(PostgresRepository::new(pool.clone()))
    }
}
```