### PR TITLE
Feature: Tags First

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Moved the "tag" parameter on all tag-based operations to the front of the method signature, for easier readability. ([#8](https://github.com/bkonkle/nakago/pull/8))
+
 ## [0.3.0] - 2023-02-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.4.0] - 2023-02-15
 
 ### Changed
 
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Injection Providers
 - Documentation
 
+[0.4.0]: https://github.com/bkonkle/nakago/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/bkonkle/nakago/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/bkonkle/nakago/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/bkonkle/nakago/releases/tag/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago"
-version = "0.3.0"
+version = "0.4.0-dev.1"
 authors = ["Brandon Konkle <brandon@konkle.us>"]
 edition = "2021"
 description = "A lightweight Rust framework for sharp services 😎"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago"
-version = "0.4.0-dev.1"
+version = "0.4.0"
 authors = ["Brandon Konkle <brandon@konkle.us>"]
 edition = "2021"
 description = "A lightweight Rust framework for sharp services 😎"

--- a/src/inject/container.rs
+++ b/src/inject/container.rs
@@ -377,15 +377,15 @@ pub(crate) mod test {
         }));
 
         if let Err(err) = result {
-            assert_eq!(
-                format!(
-                    "{} was not found\n\nAvailable:\n - {}\n\n - {}",
-                    type_name::<Box<OtherService>>(),
-                    type_name::<Box<TestService>>(),
-                    type_name::<Box<dyn HasId>>()
-                ),
-                err.to_string()
-            );
+            let message = err.to_string();
+
+            assert!(message.contains(&format!(
+                "{} was not found\n\nAvailable:",
+                type_name::<Box<OtherService>>()
+            )));
+
+            assert!(message.contains(&format!("\n - {}", type_name::<Box<TestService>>())));
+            assert!(message.contains(&format!("\n - {}", type_name::<Box<dyn HasId>>())));
         } else {
             panic!("did not return Err as expected")
         }

--- a/src/inject/tag.rs
+++ b/src/inject/tag.rs
@@ -62,8 +62,8 @@ impl Inject {
     /// Provide a tagged dependency directly
     pub fn inject_tag<T: Any + Sync + Send>(
         &mut self,
-        dep: T,
         tag: &'static Tag<T>,
+        dep: T,
     ) -> Result<(), Error> {
         self.inject_key(Key::from_tag::<T>(tag.tag), dep)
     }
@@ -71,8 +71,8 @@ impl Inject {
     /// Replace an existing tagged dependency directly
     pub fn replace_tag<T: Any + Sync + Send>(
         &mut self,
-        dep: T,
         tag: &'static Tag<T>,
+        dep: T,
     ) -> Result<(), Error> {
         self.replace_key(Key::from_tag::<T>(tag.tag), dep)
     }
@@ -102,7 +102,7 @@ pub(crate) mod test {
     fn test_inject_tag_success() -> Result<()> {
         let mut i = Inject::default();
 
-        i.inject_tag(TestService::new(fake::uuid::UUIDv4.fake()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(fake::uuid::UUIDv4.fake()))?;
 
         assert!(
             i.0.contains_key(&Key::from_tag::<TestService>(&SERVICE_TAG)),
@@ -116,10 +116,10 @@ pub(crate) mod test {
     fn test_inject_tag_occupied() -> Result<()> {
         let mut i = Inject::default();
 
-        i.inject_tag(TestService::new(fake::uuid::UUIDv4.fake()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(fake::uuid::UUIDv4.fake()))?;
 
         // Inject the same type a second time
-        let result = i.inject_tag(TestService::new(fake::uuid::UUIDv4.fake()), &SERVICE_TAG);
+        let result = i.inject_tag(&SERVICE_TAG, TestService::new(fake::uuid::UUIDv4.fake()));
 
         if let Err(err) = result {
             assert_eq!(
@@ -139,7 +139,7 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag(TestService::new(expected.clone()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(expected.clone()))?;
 
         let result = i.get_tag_opt(&SERVICE_TAG).unwrap();
 
@@ -165,7 +165,7 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag(TestService::new(expected.clone()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(expected.clone()))?;
 
         let result = i.get_tag(&SERVICE_TAG)?;
 
@@ -180,7 +180,7 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag::<Arc<dyn HasId>>(Arc::new(TestService::new(expected.clone())), &DYN_TAG)?;
+        i.inject_tag::<Arc<dyn HasId>>(&DYN_TAG, Arc::new(TestService::new(expected.clone())))?;
 
         let result = i.get_tag(&DYN_TAG)?;
 
@@ -213,7 +213,7 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag(TestService::new(expected.clone()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(expected.clone()))?;
 
         let result = i.get_tag_mut_opt(&SERVICE_TAG).unwrap();
 
@@ -239,7 +239,7 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag(TestService::new(expected.clone()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(expected.clone()))?;
 
         let result = i.get_tag_mut(&SERVICE_TAG)?;
 
@@ -272,10 +272,10 @@ pub(crate) mod test {
 
         let expected: String = fake::uuid::UUIDv4.fake();
 
-        i.inject_tag(TestService::new(fake::uuid::UUIDv4.fake()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(fake::uuid::UUIDv4.fake()))?;
 
         // Override the instance that was injected the first time
-        i.replace_tag(TestService::new(expected.clone()), &SERVICE_TAG)?;
+        i.replace_tag(&SERVICE_TAG, TestService::new(expected.clone()))?;
 
         let result = i.get_tag(&SERVICE_TAG)?;
 
@@ -288,10 +288,10 @@ pub(crate) mod test {
     fn test_replace_not_found() -> Result<()> {
         let mut i = Inject::default();
 
-        i.inject_tag(TestService::new(fake::uuid::UUIDv4.fake()), &SERVICE_TAG)?;
+        i.inject_tag(&SERVICE_TAG, TestService::new(fake::uuid::UUIDv4.fake()))?;
 
         // Override a type that doesn't have any instances yet
-        let result = i.replace_tag(OtherService::new(fake::uuid::UUIDv4.fake()), &OTHER_TAG);
+        let result = i.replace_tag(&OTHER_TAG, OtherService::new(fake::uuid::UUIDv4.fake()));
 
         if let Err(err) = result {
             assert_eq!(


### PR DESCRIPTION
Moved the "tag" parameter on all tag-based operations to the front of the method signature, for easier readability.