### PR TITLE
Release: v0.22.0

### DIFF
--- a/examples/async-graphql/Cargo.toml
+++ b/examples/async-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-examples-async-graphql"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Brandon Konkle <brandon@konkle.us>"]
 edition = "2021"
 description = "A lightweight Rust framework for sharp services 😎"
@@ -37,7 +37,7 @@ nakago = "0.20"
 nakago-async-graphql = "0.21"
 nakago-axum = "0.21"
 nakago-derive = "0.20"
-nakago-sea-orm = "0.20"
+nakago-sea-orm = "0.22"
 nakago-ws = "0.21"
 oso = "0.27"
 pico-args = "0.5.0"

--- a/nakago_sea_orm/Cargo.toml
+++ b/nakago_sea_orm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-sea-orm"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["Brandon Konkle <brandon@konkle.us>"]
 edition = "2021"
 description = "A SeaORM integration for Nakago"


### PR DESCRIPTION
## [0.22.0]

### Changed

- `nakago-sea-orm` - Removed the argument from `nakago_sea_orm::connection::Provide::new()`, because there is the with_config_tag chained helper to provide that.

[0.22.0]: https://github.com/bkonkle/nakago/compare/0.21.0...0.22.0