### PR TITLE
Fix the fake dependency by moving away from git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1]
+
+### Changed
+
+- (all packages) - Remove the `git = "<https://github.com/cksac/fake-rs.git>"` parameter from the `fake` dependency, as it is no longer needed.
+- `nakago-axum` - Change `std::panic::PanicInfo` to `std::panic::PanicHookInfo`
+
 ## [0.24.0]
 
 ### Added

--- a/examples/async-graphql/Cargo.toml
+++ b/examples/async-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-examples-async-graphql"
-version = "0.24.0"
+version = "0.24.1"
 description = "A lightweight Rust toolkit for sharp dependency injection 😎"
 license.workspace = true
 edition.workspace = true
@@ -24,12 +24,7 @@ async-trait = "0.1"
 axum = { version = "0.7", features = ["ws", "macros"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env", "toml", "yaml", "json"] }
 futures = "0.3"
 hyper = "1.0"

--- a/examples/cqrs-es/Cargo.toml
+++ b/examples/cqrs-es/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-examples-cqrs-es"
-version = "0.23.0"
+version = "0.24.1"
 description = "A lightweight Rust toolkit for sharp dependency injection 😎"
 license.workspace = true
 edition.workspace = true
@@ -20,11 +20,6 @@ nakago = "0.23"
 
 [dev-dependencies]
 criterion = "0.5"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 mockall = "0.13"
 pretty_assertions = "1.2"

--- a/examples/simple-warp/Cargo.toml
+++ b/examples/simple-warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-examples-simple-warp"
-version = "0.23.0"
+version = "0.24.1"
 description = "A lightweight Rust toolkit for sharp dependency injection 😎"
 license.workspace = true
 edition.workspace = true
@@ -17,12 +17,7 @@ integration = []
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4.19", features = ["serde"] }
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env", "toml", "yaml", "json"] }
 futures = "0.3"
 hyper = "1.0"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-examples-simple"
-version = "0.23.0"
+version = "0.24.1"
 description = "A lightweight Rust toolkit for sharp dependency injection 😎"
 license.workspace = true
 edition.workspace = true
@@ -18,12 +18,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = { version = "0.7", features = ["ws", "macros"] }
 chrono = { version = "0.4.19", features = ["serde"] }
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env", "toml", "yaml", "json"] }
 futures = "0.3"
 hyper = "1.0"

--- a/nakago/Cargo.toml
+++ b/nakago/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago"
-version = "0.23.0"
+version = "0.24.1"
 description = "A lightweight Rust toolkit for sharp dependency injection 😎"
 documentation = "https://docs.rs/nakago/"
 license.workspace = true
@@ -30,12 +30,7 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 criterion = "0.5"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 mockall = "0.13"
 pretty_assertions = "1.2"
 googletest = "0.12"

--- a/nakago_async_graphql/Cargo.toml
+++ b/nakago_async_graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-async-graphql"
-version = "0.24.0"
+version = "0.24.1"
 description = "An Async-GraphQL integration for Nakago"
 documentation = "https://docs.rs/nakago-async-graphql/"
 license.workspace = true
@@ -19,12 +19,7 @@ async-graphql-axum = { version = "6.0", git = "https://github.com/bkonkle/async-
 async-trait = "0.1"
 axum = { version = "0.7", features = ["macros"] }
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env"] }
 hyper = "1.0"
 log = "0.4"

--- a/nakago_axum/Cargo.toml
+++ b/nakago_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-axum"
-version = "0.24.0"
+version = "0.24.1"
 description = "An Axum HTTP routes integration for Nakago"
 documentation = "https://docs.rs/nakago-axum/"
 license.workspace = true
@@ -18,12 +18,7 @@ biscuit = "0.7.0"
 bytes = "1"
 crossterm = "0.28"
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env"] }
 futures-util = { version = "0.3", default-features = false, features = [
     "sink",

--- a/nakago_axum/src/init.rs
+++ b/nakago_axum/src/init.rs
@@ -1,4 +1,4 @@
-use std::{io, net::SocketAddr, panic::PanicInfo, sync::Arc};
+use std::{io, net::SocketAddr, panic::PanicHookInfo, sync::Arc};
 
 use axum::{serve::Serve, Router};
 use backtrace::Backtrace;
@@ -84,7 +84,7 @@ pub fn trace_layer() -> TraceLayer<SharedClassifier<ServerErrorsAsFailures>> {
 // --------------
 
 /// A generic function to log stacktraces on panic
-pub fn handle_panic(info: &PanicInfo<'_>) {
+pub fn handle_panic(info: &PanicHookInfo<'_>) {
     if cfg!(debug_assertions) {
         let location = info.location().unwrap();
 

--- a/nakago_figment/Cargo.toml
+++ b/nakago_figment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-figment"
-version = "0.23.0"
+version = "0.24.1"
 description = "Figment config loading utils for Nakago"
 documentation = "https://docs.rs/nakago-figment/"
 license.workspace = true
@@ -12,12 +12,7 @@ homepage.workspace = true
 [dependencies]
 anyhow = "1.0"
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env", "toml", "yaml", "json"] }
 log = "0.4"
 nakago = "0.23"

--- a/nakago_sea_orm/Cargo.toml
+++ b/nakago_sea_orm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-sea-orm"
-version = "0.23.0"
+version = "0.24.1"
 description = "A SeaORM integration for Nakago"
 documentation = "https://docs.rs/nakago-sea-orm/"
 license.workspace = true

--- a/nakago_warp/Cargo.toml
+++ b/nakago_warp/Cargo.toml
@@ -15,12 +15,7 @@ async-trait = "0.1"
 biscuit = "0.7.0"
 bytes = "1"
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 figment = { version = "0.10", features = ["env"] }
 futures-util = { version = "0.3", default-features = false, features = [
     "sink",

--- a/nakago_ws/Cargo.toml
+++ b/nakago_ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nakago-ws"
-version = "0.24.0"
+version = "0.24.1"
 description = "Websocket utils for Nakago"
 documentation = "https://docs.rs/nakago-ws/"
 license.workspace = true
@@ -15,12 +15,7 @@ async-trait = "0.1"
 axum = { version = "0.7", features = ["ws", "macros"] }
 biscuit = "0.7.0"
 derive-new = "0.7"
-fake = { version = "2.9", features = [
-    'derive',
-    'chrono',
-    'http',
-    'uuid',
-], git = "https://github.com/cksac/fake-rs.git" }
+fake = { version = "2.9", features = ['derive', 'chrono', 'http', 'uuid'] }
 futures = "0.3"
 http = "1.0.0"
 hyper = "1.0"


### PR DESCRIPTION
### Changed

- _(all packages)_ - Remove the `git = "<https://github.com/cksac/fake-rs.git>"` parameter from the `fake` dependency, as it is no longer needed.
- `nakago-axum` - Change `std::panic::PanicInfo` to `std::panic::PanicHookInfo`